### PR TITLE
Get the trashed field and decide to upload then

### DIFF
--- a/gDrive-auto-sync/upload.py
+++ b/gDrive-auto-sync/upload.py
@@ -21,8 +21,8 @@ def file_exists(fileId):
     if not fileId:
         return False
     try:
-        f = file_service.get(fileId=fileId, fields="").execute()
-        return not f.labels.trashed
+        f = file_service.get(fileId=fileId, fields="trashed").execute()
+        return not (f['trashed'])
     except Exception:
         return False
 


### PR DESCRIPTION
Checked. At max one file with the same **fileId** in drive and possible to have more than one file in Trash with the same **fileId**. I guess it checks first in drive and then in trash by default.
